### PR TITLE
Add option to ignore referrer in journey

### DIFF
--- a/template.js
+++ b/template.js
@@ -48,7 +48,7 @@ function getChannelFlow() {
         return currentChannel;
     }
 
-    if (currentChannel === 'direct/none') {
+    if (currentChannel === 'direct/none' || currentChannel === '') {
         return channelFlowCookie;
     }
 
@@ -76,6 +76,10 @@ function getCurrentChannel() {
     }
 
     const referrerHostname = parsedReferrer.hostname;
+
+    if (referrerHostname && data.ignoreReferrerExpression && referrerHostname.match(data.ignoreReferrerExpression)) {
+        return '';
+    }
 
     if (referrerHostname === parsedUrl.hostname) {
         return 'direct/none';


### PR DESCRIPTION
Add a new option that allows to ignore certain or all referrers when needed.

In our scenario, users are redirected to external payment providers in the checkout, which are picked up as referrals and then account as the last attribution channel. Having this option enables us to ignore the offending hosts and keeping the user journey clean.